### PR TITLE
Add Homebrew install to docs

### DIFF
--- a/site/site/.vitepress/config.ts
+++ b/site/site/.vitepress/config.ts
@@ -73,6 +73,7 @@ export default defineConfigWithTheme<DefaultTheme.Config>({
               link: "/cli/installation/binary",
             },
             { text: "Cargo", link: "/cli/installation/cargo" },
+            { text: "Homebrew", link: "/cli/installation/homebrew" },
             { text: "NPM", link: "/cli/installation/npm" },
             { text: "Docker", link: "/cli/installation/docker" },
           ],

--- a/site/site/cli/installation/homebrew.md
+++ b/site/site/cli/installation/homebrew.md
@@ -1,0 +1,7 @@
+# Homebrew
+
+Taplo is available on Homebrew under the [`taplo`](https://formulae.brew.sh/formula/taplo) formula.
+
+```sh
+brew install taplo
+```


### PR DESCRIPTION
There is a Homebrew formula (https://github.com/tamasfe/taplo/issues/251) but it was never added to the docs.